### PR TITLE
fixes compilation warnings on Elixir 1.10 and 1.11

### DIFF
--- a/lib/norma.ex
+++ b/lib/norma.ex
@@ -49,18 +49,16 @@ defmodule Norma do
     end
   end
 
-  @doc """
-  Solve an issue related to the regex provided by the URI spec
-  (see https://tools.ietf.org/html/rfc3986#appendix-B).
-
-  If trying to parse from string to %URI{} something like "mazing.studio:80",
-  the result will be:
-    %URI{scheme: "mazing.studio", path: "21", host: nil}
-    _(Other keys skipped for brevity, but their value is `nil`.)_
-
-  But "//mazing.studio:80", will be parsed correctly:
-    %URI{host: "mazing.studio", authority: "mazing.studio:80", port: 80}
-  """
+  # Solve an issue related to the regex provided by the URI spec
+  # (see https://tools.ietf.org/html/rfc3986#appendix-B).
+  #
+  # If trying to parse from string to %URI{} something like "mazing.studio:80",
+  # the result will be:
+  #   %URI{scheme: "mazing.studio", path: "21", host: nil}
+  #   _(Other keys skipped for brevity, but their value is `nil`.)_
+  #
+  # But "//mazing.studio:80", will be parsed correctly:
+  #   %URI{host: "mazing.studio", authority: "mazing.studio:80", port: 80}
   defp safe_parse(url) do
     url
     |> URI.parse()
@@ -78,11 +76,9 @@ defmodule Norma do
        when host != nil,
        do: url
 
-  @doc """
-  Helps discard strings that are not URLs, like mailto and javascript links.
-
-  This sure looks dumb, but a valid host will normally have at least a dot.
-  """
+  # Helps discard strings that are not URLs, like mailto and javascript links.
+  #
+  # This sure looks dumb, but a valid host will normally have at least a dot.
   defp is_url?(url) do
     cond do
       String.starts_with?(url, "mailto:") -> false

--- a/lib/norma.ex
+++ b/lib/norma.ex
@@ -49,6 +49,10 @@ defmodule Norma do
     end
   end
 
+  #####################
+  # Private functions #
+  #####################
+
   # Solve an issue related to the regex provided by the URI spec
   # (see https://tools.ietf.org/html/rfc3986#appendix-B).
   #

--- a/lib/norma/normalizer.ex
+++ b/lib/norma/normalizer.ex
@@ -1,83 +1,79 @@
 defmodule Norma.Normalizer do
-  alias Norma.{Utils}
-
-  @moduledoc """
-  `normalize/2` reduces the given URL and options until these conditions
-  are met:
-    1. `options == %{}`
-    2. `url.scheme != nil`
-  """
+  alias Norma.Utils
 
   @doc """
-  Leave the scheme blank.
+  Normalizes the given `url`, accepts the following options:
+
+    - `remove_fragment`
+    - `force_root_path`
+    - `add_trailing_slash`
+    - `remove_www`
+    - `downcase_host`
   """
-  def normalize(url, options = %{remove_scheme: true}) do
+  def normalize(url, options \\ %{}), do: reduce_normalize(url, options)
+
+  #####################
+  # Private functions #
+  #####################
+
+  # `reduce_normalize/2` reduces the given URL and options until these conditions are met:
+  #  1. `options == %{}`
+  #  2. `url.scheme != nil`
+
+  # Leaves the scheme blank.
+  defp reduce_normalize(url, options = %{remove_scheme: true}) do
     url
     |> add_blank_scheme
-    |> normalize(options |> Map.drop([:remove_scheme]))
+    |> reduce_normalize(options |> Map.drop([:remove_scheme]))
   end
 
-  @doc """
-  Handles a missing scheme. Defaults to `http` or infers it from the port.
-  """
-  def normalize(url = %URI{scheme: nil}, options) do
+  # Handles a missing scheme. Defaults to `http` or infers it from the port.
+  defp reduce_normalize(url = %URI{scheme: nil}, options) do
     url
     |> infer_scheme
-    |> normalize(options)
+    |> reduce_normalize(options)
   end
 
-  @doc """
-  Removes URL fragments.
-  """
-  def normalize(url = %URI{fragment: fragment}, options = %{remove_fragment: true})
-      when fragment != nil do
+  # Removes URL fragments.
+  defp reduce_normalize(url = %URI{fragment: fragment}, options = %{remove_fragment: true})
+       when fragment != nil do
     url
     |> remove_fragment
-    |> normalize(options |> Map.drop([:remove_fragment]))
+    |> reduce_normalize(options |> Map.drop([:remove_fragment]))
   end
 
-  @doc """
-  Forces path to be "/".
-  """
-  def normalize(url = %URI{path: path}, options = %{force_root_path: true})
-      when path != "/" do
+  # Forces path to be "/".
+  defp reduce_normalize(url = %URI{path: path}, options = %{force_root_path: true})
+       when path != "/" do
     url
     |> force_root_path
-    |> normalize(options |> Map.drop([:force_root_path]))
+    |> reduce_normalize(options |> Map.drop([:force_root_path]))
   end
 
-  @doc """
-  Adds a trailing slash to the path unless it's already "/" or has an extension
-  """
-  def normalize(url = %URI{path: path}, options = %{add_trailing_slash: true})
-      when path != "/" do
+  # Adds a trailing slash to the path unless it's already "/" or has an extension
+  defp reduce_normalize(url = %URI{path: path}, options = %{add_trailing_slash: true})
+       when path != "/" do
     url
     |> add_trailing_slash()
-    |> normalize(options |> Map.drop([:add_trailing_slash]))
+    |> reduce_normalize(options |> Map.drop([:add_trailing_slash]))
   end
 
-  @doc """
-  Removes "www." from the host.
-  """
-  def normalize(url, options = %{remove_www: true}) do
+  # Removes "www." from the host.
+  defp reduce_normalize(url, options = %{remove_www: true}) do
     url
     |> remove_www
-    |> normalize(options |> Map.drop([:remove_www]))
+    |> reduce_normalize(options |> Map.drop([:remove_www]))
   end
 
-  @doc """
-  Downcases host.
-  """
-  def normalize(url, options = %{downcase_host: true}) do
+  # Downcases host.
+  defp reduce_normalize(url, options = %{downcase_host: true}) do
     url
     |> downcase_host()
-    |> normalize(options |> Map.drop([:downcase_host]))
+    |> reduce_normalize(options |> Map.drop([:downcase_host]))
   end
 
-  @doc """
-  If the URL elements are valid now, forms a string.
-  """
-  def normalize(url, %{}), do: url |> Utils.form_url()
+  # If the URL elements are valid now, forms a string.
+  defp reduce_normalize(url, %{}), do: url |> Utils.form_url()
 
   defp add_blank_scheme(url), do: url |> Map.put(:scheme, "")
 

--- a/lib/norma/utils.ex
+++ b/lib/norma/utils.ex
@@ -47,6 +47,10 @@ defmodule Norma.Utils do
     |> Kernel.<>(form_query(query))
   end
 
+  #####################
+  # Private functions #
+  #####################
+
   defp form_scheme(""), do: ""
   defp form_scheme(scheme), do: scheme <> "://"
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,8 +5,8 @@ defmodule Norma.Mixfile do
     [
       app: :norma,
       version: "1.8.4",
-      elixir: "~> 1.3",
-      start_permanent: Mix.env == :prod,
+      elixir: "~> 1.11",
+      start_permanent: Mix.env() == :prod,
       description: description(),
       package: package(),
       deps: deps(),


### PR DESCRIPTION
Hello!

This PR fixes compilation warnings: 

## Elixir 1.10

> private functions can't have `@doc`, so instead I converted them to comments.

## Elixir 1.11

> Please remove the duplicate docs. If instead you want to override a previously defined `@doc`, attach the `@doc` attribute to a function head:

